### PR TITLE
fix dockerfile to point into prebuild node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 
 FROM node:latest
 
-WORKDIR /app
+WORKDIR /home/node
 
 COPY ["package.json", "package-lock.json*", "./"]
 
-RUN npm install 
+RUN npm install
 
+WORKDIR /app
+ENV NODE_PATH=/home/node/node_modules
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 
 FROM node:latest
 
-WORKDIR /home/node
-
+WORKDIR /home/project
 COPY ["package.json", "package-lock.json*", "./"]
 
-RUN npm install
+RUN npm install 
+RUN npm config set scripts-prepend-node-path auto
 
 WORKDIR /app
-ENV NODE_PATH=/home/node/node_modules
-CMD ["npm", "start"]
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Interactive:
 ```
 ```
 Noninteractive:
-> docker run -d --network host -v $/home/bazyli/gitworkspace/WPZ/WPZ-Backend:/app bkstud/wpzbackend:latest
+> docker run -d --network host -v /home/bazyli/gitworkspace/WPZ/WPZ-Backend:/app bkstud/wpzbackend:latest
+```
+```
+For windows WSL it did not work with '--network host' flag instead following given the same result:
+> docker run -it -p 3002:3002 -v $(pwd):/app bkstud/wpzbackend:latest
 ```
 
 ```
-To test if works curl should show Express aplication
+To test if works curl should show Express aplication:
 > curl -v localhost:3002/api
 ```

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+shopt -s extglob
+cp -r !(node_modules) /home/project
+cd /home/project
+npm install
+npm start


### PR DESCRIPTION
Był problem, że npm nie miał ustawionej zmiennej ze ścieżką do `node_modules`, które powinny być wcześniej już zbudowane w obrazie. Zamiast tego wcześniej zbudowane `node_modules` mogły być nadpisane przez te, które znajdują się w katalogu hosta `/app`.